### PR TITLE
Fix Ractor safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Fix Ractor safety
 - Make `ArgumentError` messages consistent
 - Implement write barriers for `Atom`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-- Fix Ractor safety
+- Fix Ractor safety (requires Ruby 3.5+)
 - Make `ArgumentError` messages consistent
 - Implement write barriers for `Atom`
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ p latch.count #=> 0
 ```
 
 > [!NOTE]
-> `Atom`, `AtomicBoolean`, and `AtomicCountDownLatch` are also Ractor safe in Ruby 3.5 and later.
+> `Atom`, `AtomicBoolean`, and `AtomicCountDownLatch` are Ractor-safe in Ruby 3.5+.
 >
-> When storing procs in atoms, including when queueing them with `AtomicThreadPool#<<`, you will
-> need to create them using `Ractor.shareable_proc` as the `Ractor.make_shareable` API utilised by
-> this gem cannot convert regular procs to shareable ones.
+> When storing procs in atoms (including queueing them with `AtomicThreadPool#<<`), create them
+> using `Ractor.shareable_proc`, as `Ractor.make_shareable` cannot convert regular procs to
+> shareable ones when the proc's context is not shareable.
 >
 > ```ruby
-> # This will raise an error in Ruby 3.5+
-> atom = Atom.new(-> { puts "hello" })
+> # This will raise an error in Ruby 3.5+ (proc created in non-shareable context)
+> atom = Atom.new(proc { puts "hello" })
 >
 > # Use this instead
 > atom = Atom.new(Ractor.shareable_proc { puts "hello" })
@@ -363,11 +363,11 @@ results = []
     end
 
     100.times do
-      pool << -> { sleep(0.2) }
+      pool << proc { sleep(0.2) }
     end
 
     100.times do
-      pool << -> { 1_000_000.times.map(&:itself).sum }
+      pool << proc { 1_000_000.times.map(&:itself).sum }
     end
 
     pool.shutdown

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ p latch.count #=> 0
 
 > [!NOTE]
 > `Atom`, `AtomicBoolean`, and `AtomicCountDownLatch` are also Ractor safe in Ruby 3.5 and later.
+>
+> When storing procs in atoms, including when queueing them with `AtomicThreadPool#<<`, you will
+> need to create them using `Ractor.shareable_proc` as the `Ractor.make_shareable` API utilised by
+> this gem cannot convert regular procs to shareable ones.
+>
+> ```ruby
+> # This will raise an error in Ruby 3.5+
+> atom = Atom.new(-> { puts "hello" })
+>
+> # Use this instead
+> atom = Atom.new(Ractor.shareable_proc { puts "hello" })
+> ```
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ p latch.count #=> 0
 ```
 
 > [!NOTE]
-> `Atom`, `AtomicBoolean`, and `AtomicCountDownLatch` are also Ractor safe.
+> `Atom`, `AtomicBoolean`, and `AtomicCountDownLatch` are also Ractor safe in Ruby 3.5 and later.
 
 ## Benchmarks
 

--- a/examples/atomic_thread_pool_benchmark.rb
+++ b/examples/atomic_thread_pool_benchmark.rb
@@ -14,11 +14,11 @@ results = []
     end
 
     100.times do
-      pool << -> { sleep(0.2) }
+      pool << proc { sleep(0.2) }
     end
 
     100.times do
-      pool << -> { 1_000_000.times.map(&:itself).sum }
+      pool << proc { 1_000_000.times.map(&:itself).sum }
     end
 
     pool.shutdown

--- a/ext/atomic_ruby/atomic_ruby.c
+++ b/ext/atomic_ruby/atomic_ruby.c
@@ -41,9 +41,9 @@ static VALUE rb_cAtom_allocate(VALUE klass) {
   return obj;
 }
 
-static void check_value_shareable(VALUE val) {
-  if (!rb_ractor_shareable_p(val)) {
-    rb_raise(rb_eArgError, "only shareable objects are allowed");
+static void check_value_shareable(VALUE value) {
+  if (!rb_ractor_shareable_p(value)) {
+    rb_raise(rb_eArgError, "value must be a shareable object");
   }
 }
 

--- a/ext/atomic_ruby/atomic_ruby.c
+++ b/ext/atomic_ruby/atomic_ruby.c
@@ -31,7 +31,11 @@ static const rb_data_type_t atomic_ruby_atom_type = {
     .dsize = atomic_ruby_atom_memsize,
     .dcompact = atomic_ruby_atom_compact
   },
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FROZEN_SHAREABLE
+#else
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+#endif
 };
 
 static VALUE rb_cAtom_allocate(VALUE klass) {
@@ -41,7 +45,7 @@ static VALUE rb_cAtom_allocate(VALUE klass) {
   return obj;
 }
 
-#ifdef HAVE_RACTOR_SHAREABLE_PROC
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
 static void check_value_shareable(VALUE value) {
   if (!rb_ractor_shareable_p(value)) {
     rb_raise(rb_eArgError, "value must be a shareable object");
@@ -52,7 +56,7 @@ static void check_value_shareable(VALUE value) {
 static VALUE rb_cAtom_initialize(VALUE self, VALUE value) {
   atomic_ruby_atom_t *atomic_ruby_atom;
   TypedData_Get_Struct(self, atomic_ruby_atom_t, &atomic_ruby_atom_type, atomic_ruby_atom);
-#ifdef HAVE_RACTOR_SHAREABLE_PROC
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
   check_value_shareable(value);
 #endif
   RB_OBJ_WRITE(self, &atomic_ruby_atom->value, value);
@@ -73,7 +77,7 @@ static VALUE rb_cAtom_swap(VALUE self) {
   do {
     expected_old_value = atomic_ruby_atom->value;
     new_value = rb_yield(expected_old_value);
-#ifdef HAVE_RACTOR_SHAREABLE_PROC
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
     check_value_shareable(new_value);
 #endif
   } while (RUBY_ATOMIC_VALUE_CAS(atomic_ruby_atom->value, expected_old_value, new_value) != expected_old_value);
@@ -83,7 +87,7 @@ static VALUE rb_cAtom_swap(VALUE self) {
 }
 
 RUBY_FUNC_EXPORTED void Init_atomic_ruby(void) {
-#if defined(HAVE_RB_EXT_RACTOR_SAFE) && defined(HAVE_RACTOR_SHAREABLE_PROC)
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
   rb_ext_ractor_safe(true);
 #endif
 
@@ -94,4 +98,10 @@ RUBY_FUNC_EXPORTED void Init_atomic_ruby(void) {
   rb_define_method(rb_cAtom, "_initialize", rb_cAtom_initialize, 1);
   rb_define_method(rb_cAtom, "_value", rb_cAtom_value, 0);
   rb_define_method(rb_cAtom, "_swap", rb_cAtom_swap, 0);
+
+#ifdef ATOMIC_RUBY_RACTOR_SAFE
+  rb_define_const(rb_mAtomicRuby, "RACTOR_SAFE", Qtrue);
+#else
+  rb_define_const(rb_mAtomicRuby, "RACTOR_SAFE", Qfalse);
+#endif
 }

--- a/ext/atomic_ruby/atomic_ruby.h
+++ b/ext/atomic_ruby/atomic_ruby.h
@@ -4,5 +4,10 @@
 #include "ruby.h"
 #include "ruby/atomic.h"
 #include "ruby/ractor.h"
+#include "ruby/version.h"
+
+#if RUBY_API_VERSION_CODE >= 30500
+#define ATOMIC_RUBY_RACTOR_SAFE 1
+#endif
 
 #endif /* ATOMIC_RUBY_ATOM_H */

--- a/ext/atomic_ruby/atomic_ruby.h
+++ b/ext/atomic_ruby/atomic_ruby.h
@@ -3,5 +3,6 @@
 
 #include "ruby.h"
 #include "ruby/atomic.h"
+#include "ruby/ractor.h"
 
 #endif /* ATOMIC_RUBY_ATOM_H */

--- a/ext/atomic_ruby/extconf.rb
+++ b/ext/atomic_ruby/extconf.rb
@@ -7,8 +7,4 @@ require "mkmf"
 # selectively, or entirely remove this flag.
 append_cflags("-fvisibility=hidden")
 
-if Ractor.respond_to?(:shareable_proc)
-  $defs << "-DHAVE_RACTOR_SHAREABLE_PROC"
-end
-
 create_makefile("atomic_ruby/atomic_ruby")

--- a/ext/atomic_ruby/extconf.rb
+++ b/ext/atomic_ruby/extconf.rb
@@ -7,4 +7,8 @@ require "mkmf"
 # selectively, or entirely remove this flag.
 append_cflags("-fvisibility=hidden")
 
+if Ractor.respond_to?(:shareable_proc)
+  $defs << "-DHAVE_RACTOR_SHAREABLE_PROC"
+end
+
 create_makefile("atomic_ruby/atomic_ruby")

--- a/lib/atomic-ruby/atom.rb
+++ b/lib/atomic-ruby/atom.rb
@@ -3,9 +3,12 @@
 require "atomic_ruby/atomic_ruby"
 
 module AtomicRuby
+  RACTOR_SHAREABLE_PROC = Ractor.respond_to?(:shareable_proc)
+  private_constant :RACTOR_SHAREABLE_PROC
+
   class Atom
     def initialize(value)
-      _initialize(Ractor.make_shareable(value))
+      _initialize(make_shareable(value))
 
       freeze
     end
@@ -16,7 +19,17 @@ module AtomicRuby
 
     def swap(&block)
       _swap do |old_value|
-        Ractor.make_shareable(block.call(old_value))
+        make_shareable(block.call(old_value))
+      end
+    end
+
+    private
+
+    def make_shareable(value)
+      if RACTOR_SHAREABLE_PROC
+        Ractor.make_shareable(value)
+      else
+        value
       end
     end
   end

--- a/lib/atomic-ruby/atom.rb
+++ b/lib/atomic-ruby/atom.rb
@@ -15,7 +15,9 @@ module AtomicRuby
     end
 
     def swap(&block)
-      _swap { |old_value| Ractor.make_shareable(yield(old_value)) }
+      _swap do |old_value|
+        Ractor.make_shareable(block.call(old_value))
+      end
     end
   end
 end

--- a/lib/atomic-ruby/atom.rb
+++ b/lib/atomic-ruby/atom.rb
@@ -5,9 +5,9 @@ require "atomic_ruby/atomic_ruby"
 module AtomicRuby
   class Atom
     def initialize(value)
-      _initialize(value)
+      _initialize(Ractor.make_shareable(value))
 
-      Ractor.make_shareable(self)
+      freeze
     end
 
     def value
@@ -15,7 +15,7 @@ module AtomicRuby
     end
 
     def swap(&block)
-      _swap(&block)
+      _swap { |old_value| Ractor.make_shareable(yield(old_value)) }
     end
   end
 end

--- a/lib/atomic-ruby/atom.rb
+++ b/lib/atomic-ruby/atom.rb
@@ -3,14 +3,11 @@
 require "atomic_ruby/atomic_ruby"
 
 module AtomicRuby
-  RACTOR_SHAREABLE_PROC = Ractor.respond_to?(:shareable_proc)
-  private_constant :RACTOR_SHAREABLE_PROC
-
   class Atom
     def initialize(value)
       _initialize(make_shareable(value))
 
-      freeze
+      freeze if RACTOR_SAFE
     end
 
     def value
@@ -26,7 +23,7 @@ module AtomicRuby
     private
 
     def make_shareable(value)
-      if RACTOR_SHAREABLE_PROC
+      if RACTOR_SAFE
         Ractor.make_shareable(value)
       else
         value

--- a/lib/atomic-ruby/atomic_boolean.rb
+++ b/lib/atomic-ruby/atomic_boolean.rb
@@ -11,7 +11,7 @@ module AtomicRuby
 
       @boolean = Atom.new(boolean)
 
-      freeze
+      Ractor.make_shareable(self) if RACTOR_SAFE
     end
 
     def value

--- a/lib/atomic-ruby/atomic_boolean.rb
+++ b/lib/atomic-ruby/atomic_boolean.rb
@@ -11,7 +11,7 @@ module AtomicRuby
 
       @boolean = Atom.new(boolean)
 
-      Ractor.make_shareable(self)
+      freeze
     end
 
     def value

--- a/lib/atomic-ruby/atomic_count_down_latch.rb
+++ b/lib/atomic-ruby/atomic_count_down_latch.rb
@@ -14,7 +14,7 @@ module AtomicRuby
 
       @count = Atom.new(count)
 
-      Ractor.make_shareable(self)
+      freeze
     end
 
     def count

--- a/lib/atomic-ruby/atomic_count_down_latch.rb
+++ b/lib/atomic-ruby/atomic_count_down_latch.rb
@@ -14,7 +14,7 @@ module AtomicRuby
 
       @count = Atom.new(count)
 
-      freeze
+      Ractor.make_shareable(self) if RACTOR_SAFE
     end
 
     def count

--- a/test/atomic-ruby/test_atom.rb
+++ b/test/atomic-ruby/test_atom.rb
@@ -25,7 +25,9 @@ class TestAtom < Minitest::Test
     atom = Atom.new(0)
     ractors = 10.times.map do
       Ractor.new(atom) do |shared_atom|
-        shared_atom.swap { |current| current + 1 }
+        shared_atom.swap { |current|
+          current + 1
+        }
       end
     end
     RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)

--- a/test/atomic-ruby/test_atom.rb
+++ b/test/atomic-ruby/test_atom.rb
@@ -25,9 +25,7 @@ class TestAtom < Minitest::Test
     atom = Atom.new(0)
     ractors = 10.times.map do
       Ractor.new(atom) do |shared_atom|
-        shared_atom.swap { |current|
-          current + 1
-        }
+        shared_atom.swap { |current| current + 1 }
       end
     end
     RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)

--- a/test/atomic-ruby/test_atom.rb
+++ b/test/atomic-ruby/test_atom.rb
@@ -8,9 +8,11 @@ class TestAtom < Minitest::Test
     assert_equal 0, atom.value
   end
 
-  def test_shareable
-    atom = Atom.new(0)
-    assert Ractor.shareable?(atom)
+  if RUBY_VERSION >= "3.5"
+    def test_shareable
+      atom = Atom.new(0)
+      assert Ractor.shareable?(atom)
+    end
   end
 
   def test_swap
@@ -21,14 +23,16 @@ class TestAtom < Minitest::Test
     assert_equal 2, atom.value
   end
 
-  def test_swap_in_ractor
-    atom = Atom.new(0)
-    ractors = 10.times.map do
-      Ractor.new(atom) do |shared_atom|
-        shared_atom.swap { |current| current + 1 }
+  if RUBY_VERSION >= "3.5"
+    def test_swap_in_ractor
+      atom = Atom.new(0)
+      ractors = 10.times.map do
+        Ractor.new(atom) do |shared_atom|
+          shared_atom.swap { |current| current + 1 }
+        end
       end
+      ractors.each(&:value)
+      assert_equal 10, atom.value
     end
-    RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)
-    assert_equal 10, atom.value
   end
 end

--- a/test/atomic-ruby/test_atom.rb
+++ b/test/atomic-ruby/test_atom.rb
@@ -8,10 +8,22 @@ class TestAtom < Minitest::Test
     assert_equal 0, atom.value
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_shareable
       atom = Atom.new(0)
       assert Ractor.shareable?(atom)
+    end
+
+    def test_not_shareable_init
+      assert_raises Ractor::IsolationError do
+        Atom.new(proc { })
+      end
+    end
+
+    def test_shareable_init
+      proc = Ractor.shareable_proc { }
+      atom = Atom.new(proc)
+      assert_equal proc, atom.value
     end
   end
 
@@ -23,7 +35,7 @@ class TestAtom < Minitest::Test
     assert_equal 2, atom.value
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_swap_in_ractor
       atom = Atom.new(0)
       ractors = 10.times.map do

--- a/test/atomic-ruby/test_atomic_boolean.rb
+++ b/test/atomic-ruby/test_atomic_boolean.rb
@@ -9,7 +9,7 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_shareable
       boolean = AtomicBoolean.new(true)
       assert Ractor.shareable?(boolean)
@@ -23,7 +23,7 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :true?
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_make_true_in_ractor
       boolean = AtomicBoolean.new(false)
       ractors = 10.times.map do
@@ -44,7 +44,7 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_make_false_in_ractor
       boolean = AtomicBoolean.new(true)
       ractors = 10.times.map do
@@ -65,7 +65,7 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_toggle_in_ractor
       boolean = AtomicBoolean.new(true)
       ractors = 10.times.map do

--- a/test/atomic-ruby/test_atomic_boolean.rb
+++ b/test/atomic-ruby/test_atomic_boolean.rb
@@ -9,9 +9,11 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  def test_shareable
-    boolean = AtomicBoolean.new(true)
-    assert Ractor.shareable?(boolean)
+  if RUBY_VERSION >= "3.5"
+    def test_shareable
+      boolean = AtomicBoolean.new(true)
+      assert Ractor.shareable?(boolean)
+    end
   end
 
   def test_make_true
@@ -21,16 +23,18 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :true?
   end
 
-  def test_make_true_in_ractor
-    boolean = AtomicBoolean.new(false)
-    ractors = 10.times.map do
-      Ractor.new(boolean) do |shared_boolean|
-        shared_boolean.make_true
+  if RUBY_VERSION >= "3.5"
+    def test_make_true_in_ractor
+      boolean = AtomicBoolean.new(false)
+      ractors = 10.times.map do
+        Ractor.new(boolean) do |shared_boolean|
+          shared_boolean.make_true
+        end
       end
+      ractors.each(&:value)
+      assert_equal true, boolean.value
+      assert_predicate boolean, :true?
     end
-    RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)
-    assert_equal true, boolean.value
-    assert_predicate boolean, :true?
   end
 
   def test_make_false
@@ -40,16 +44,18 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  def test_make_false_in_ractor
-    boolean = AtomicBoolean.new(true)
-    ractors = 10.times.map do
-      Ractor.new(boolean) do |shared_boolean|
-        shared_boolean.make_false
+  if RUBY_VERSION >= "3.5"
+    def test_make_false_in_ractor
+      boolean = AtomicBoolean.new(true)
+      ractors = 10.times.map do
+        Ractor.new(boolean) do |shared_boolean|
+          shared_boolean.make_false
+        end
       end
+      ractors.each(&:value)
+      assert_equal false, boolean.value
+      assert_predicate boolean, :false?
     end
-    RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)
-    assert_equal false, boolean.value
-    assert_predicate boolean, :false?
   end
 
   def test_toggle
@@ -59,15 +65,17 @@ class TestAtomicBoolean < Minitest::Test
     assert_predicate boolean, :false?
   end
 
-  def test_toggle_in_ractor
-    boolean = AtomicBoolean.new(true)
-    ractors = 10.times.map do
-      Ractor.new(boolean) do |shared_boolean|
-        shared_boolean.toggle
+  if RUBY_VERSION >= "3.5"
+    def test_toggle_in_ractor
+      boolean = AtomicBoolean.new(true)
+      ractors = 10.times.map do
+        Ractor.new(boolean) do |shared_boolean|
+          shared_boolean.toggle
+        end
       end
+      ractors.each(&:value)
+      assert_equal true, boolean.value
+      assert_predicate boolean, :true?
     end
-    RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)
-    assert_equal true, boolean.value
-    assert_predicate boolean, :true?
   end
 end

--- a/test/atomic-ruby/test_atomic_count_down_latch.rb
+++ b/test/atomic-ruby/test_atomic_count_down_latch.rb
@@ -61,7 +61,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     latch = AtomicCountDownLatch.new(5)
     pool = AtomicThreadPool.new(size: 2)
     5.times do
-      pool << -> {
+      pool << Ractor.shareable_proc {
         sleep 0.1
         latch.count_down
       }

--- a/test/atomic-ruby/test_atomic_count_down_latch.rb
+++ b/test/atomic-ruby/test_atomic_count_down_latch.rb
@@ -8,7 +8,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     assert_equal 5, latch.count
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_shareable
       latch = AtomicCountDownLatch.new(5)
       assert Ractor.shareable?(latch)
@@ -40,7 +40,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     end
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_count_down_in_ractor
       latch = AtomicCountDownLatch.new(10)
       ractors = 10.times.map do
@@ -65,7 +65,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     latch = AtomicCountDownLatch.new(5)
     pool = AtomicThreadPool.new(size: 2)
     5.times do
-      pool << work_proc {
+      pool << shareable_proc {
         sleep 0.1
         latch.count_down
       }
@@ -74,7 +74,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     assert_equal 0, latch.count
   end
 
-  if RUBY_VERSION >= "3.5"
+  if AtomicRuby::RACTOR_SAFE
     def test_wait_in_ractor
       latch = AtomicCountDownLatch.new(5)
       countdown_ractors = 5.times.map do
@@ -94,8 +94,8 @@ class TestAtomicCountDownLatch < Minitest::Test
 
   private
 
-  def work_proc(&work)
-    if RUBY_VERSION >= "3.5"
+  def shareable_proc(&work)
+    if AtomicRuby::RACTOR_SAFE
       Ractor.shareable_proc(&work)
     else
       work

--- a/test/atomic-ruby/test_atomic_count_down_latch.rb
+++ b/test/atomic-ruby/test_atomic_count_down_latch.rb
@@ -8,9 +8,11 @@ class TestAtomicCountDownLatch < Minitest::Test
     assert_equal 5, latch.count
   end
 
-  def test_shareable
-    latch = AtomicCountDownLatch.new(5)
-    assert Ractor.shareable?(latch)
+  if RUBY_VERSION >= "3.5"
+    def test_shareable
+      latch = AtomicCountDownLatch.new(5)
+      assert Ractor.shareable?(latch)
+    end
   end
 
   def test_with_invalid_count
@@ -38,15 +40,17 @@ class TestAtomicCountDownLatch < Minitest::Test
     end
   end
 
-  def test_count_down_in_ractor
-    latch = AtomicCountDownLatch.new(10)
-    ractors = 10.times.map do
-      Ractor.new(latch) do |shared_latch|
-        shared_latch.count_down
+  if RUBY_VERSION >= "3.5"
+    def test_count_down_in_ractor
+      latch = AtomicCountDownLatch.new(10)
+      ractors = 10.times.map do
+        Ractor.new(latch) do |shared_latch|
+          shared_latch.count_down
+        end
       end
+      ractors.each(&:value)
+      assert_equal 0, latch.count
     end
-    RUBY_VERSION >= "3.5" ? ractors.each(&:value) : ractors.each(&:take)
-    assert_equal 0, latch.count
   end
 
   def test_wait
@@ -61,7 +65,7 @@ class TestAtomicCountDownLatch < Minitest::Test
     latch = AtomicCountDownLatch.new(5)
     pool = AtomicThreadPool.new(size: 2)
     5.times do
-      pool << Ractor.shareable_proc {
+      pool << work_proc {
         sleep 0.1
         latch.count_down
       }
@@ -70,24 +74,31 @@ class TestAtomicCountDownLatch < Minitest::Test
     assert_equal 0, latch.count
   end
 
-  def test_wait_in_ractor
-    latch = AtomicCountDownLatch.new(5)
-    countdown_ractors = 5.times.map do
-      Ractor.new(latch) do |shared_latch|
-        shared_latch.count_down
+  if RUBY_VERSION >= "3.5"
+    def test_wait_in_ractor
+      latch = AtomicCountDownLatch.new(5)
+      countdown_ractors = 5.times.map do
+        Ractor.new(latch) do |shared_latch|
+          shared_latch.count_down
+        end
       end
-    end
-    wait_ractor = Ractor.new(latch) do |shared_latch|
-      shared_latch.wait
-      shared_latch.count
-    end
-    result = if RUBY_VERSION >= "3.5"
+      wait_ractor = Ractor.new(latch) do |shared_latch|
+        shared_latch.wait
+        shared_latch.count
+      end
       countdown_ractors.each(&:value)
-      wait_ractor.value
-    else
-      countdown_ractors.each(&:take)
-      wait_ractor.take
+      result = wait_ractor.value
+      assert_equal 0, result
     end
-    assert_equal 0, result
+  end
+
+  private
+
+  def work_proc(&work)
+    if RUBY_VERSION >= "3.5"
+      Ractor.shareable_proc(&work)
+    else
+      work
+    end
   end
 end

--- a/test/atomic-ruby/test_atomic_thread_pool.rb
+++ b/test/atomic-ruby/test_atomic_thread_pool.rb
@@ -9,10 +9,12 @@ class TestAtomicThreadPool < Minitest::Test
     assert_equal 0, pool.queue_length
   end
 
-  def test_not_shareable
-    pool = AtomicThreadPool.new(size: 2)
-    refute Ractor.shareable?(pool)
-    pool.shutdown
+  if RUBY_VERSION >= "3.5"
+    def test_not_shareable
+      pool = AtomicThreadPool.new(size: 2)
+      refute Ractor.shareable?(pool)
+      pool.shutdown
+    end
   end
 
   def test_start
@@ -27,27 +29,37 @@ class TestAtomicThreadPool < Minitest::Test
     assert_equal 0, Thread.list.count { |thread| thread.name =~ /AtomicThreadPool thread \d+ for Test Pool/ }
   end
 
-  def test_enqueue
-    result_port = Ractor::Port.new
-    pool = AtomicThreadPool.new(size: 2)
-    5.times { |idx| pool << Ractor.shareable_proc { result_port << idx + 1 } }
-    pool.shutdown
-    results = 5.times.map { result_port.receive }
-    assert_equal [1, 2, 3, 4, 5], results.sort
+  if RUBY_VERSION >= "3.5"
+    def test_enqueue
+      result_port = Ractor::Port.new
+      pool = AtomicThreadPool.new(size: 2)
+      5.times { |idx| pool << work_proc { result_port << idx + 1 } }
+      pool.shutdown
+      results = 5.times.map { result_port.receive }
+      assert_equal [1, 2, 3, 4, 5], results.sort
+    end
+  else
+    def test_enqueue
+      results = []
+      pool = AtomicThreadPool.new(size: 2)
+      5.times { |idx| pool << -> { results << idx + 1 } }
+      pool.shutdown
+      assert_equal [1, 2, 3, 4, 5], results.sort
+    end
   end
 
   def test_enqueue_after_shutdown
     pool = AtomicThreadPool.new(size: 2)
     pool.shutdown
     assert_raises AtomicThreadPool::EnqueuedWorkAfterShutdownError do
-      pool << -> {}
+      pool << work_proc {}
     end
   end
 
   def test_enqueue_error_raising_work
     pool = AtomicThreadPool.new(size: 2)
     out, _err = capture_io do
-      pool << Ractor.shareable_proc { raise "oops" }
+      pool << work_proc { raise "oops" }
       sleep 1
     end
     assert_match(/AtomicThreadPool thread \d+ rescued:\nRuntimeError: oops/, out)
@@ -63,9 +75,19 @@ class TestAtomicThreadPool < Minitest::Test
 
   def test_enqueue_length
     pool = AtomicThreadPool.new(size: 2)
-    5.times { pool << Ractor.shareable_proc { sleep 1 } }
+    5.times { pool << work_proc { sleep 1 } }
     assert_operator pool.queue_length, :>=, 3
     pool.shutdown
     assert_equal 0, pool.queue_length
+  end
+
+  private
+
+  def work_proc(&work)
+    if RUBY_VERSION >= "3.5"
+      Ractor.shareable_proc(&work)
+    else
+      work
+    end
   end
 end


### PR DESCRIPTION
Unshareable objects can't be sent to ractors as today these objects are unsafe to concurrently modify. In the future (under Ractor-local GC) this will be even more broken and reading from the objects may also break (as they could be GC'd).

This enforces shareability in the C extension, and adjusts tests to work using some Ruby 3.5 specific features. Some of the patterns here (sharing a proc) I don't know of a way to make work on Ruby 3.4 and I don't think we should bother.

Either this needs to be done, or these objects should not be marked as Ractor-shareable